### PR TITLE
hotfix/github dft dploy actions

### DIFF
--- a/src/jobs/ecr-build-and-push.yml
+++ b/src/jobs/ecr-build-and-push.yml
@@ -3,6 +3,10 @@ description: |
   Needs contexts: [SLACK, TESTS, (BUILD_AND_PUSH|DEPLOY_LIVE|DEPLOY_QA)]
 executor: default
 parameters:
+  repo_name:
+    type: string
+    default: ${CIRCLE_PROJECT_REPONAME}
+    description: The aws ecr registry name
   rev_txt_path:
     type: string
     default: rev.txt
@@ -32,7 +36,7 @@ steps:
   - aws-ecr/build-and-push-image:
       checkout: false
       # create-repo: true # TODO: needs to talk about with SRE team
-      repo: ${CIRCLE_PROJECT_REPONAME}
+      repo: <<parameters.repo_name>>
       tag: <<parameters.build_tag>>
       extra-build-args: <<parameters.extra-build-args>>
   - slack/notify:

--- a/src/scripts/github-approve-prs.sh
+++ b/src/scripts/github-approve-prs.sh
@@ -3,13 +3,19 @@
 if [[ $(gh pr list) ]]; then
   echo "PR open listed. Notify to update"
   gh pr list | awk '{print$1}' | while read -r line; do
-    gh pr review $line --request-changes --body "The staging env was chaged! You need to re-run this pipeline to create a new deploy to staging"
+    if [ $(gh pr view $line --json author --jq '.author.login') != "dft-deploy" ]; then
+      gh pr review $line --request-changes --body "The staging env was chaged! You need to re-run this pipeline to create a new deploy to staging"
+    fi
   done
 fi
 if [[ $(gh pr list -H ${CIRCLE_BRANCH}) ]]; then
   echo "PR open listed. APPROVE"
   gh pr list -H ${CIRCLE_BRANCH} | awk '{print$1}' | while read -r line; do
-    gh pr review $line --approve --body "Thi PR is ready to merge!"
+    if [ $(gh pr view $line --json author --jq '.author.login') != "dft-deploy" ]; then
+      gh pr review $line --approve --body "Thi PR is ready to merge!"
+    else
+      gh pr close $line
+    fi
   done
 else
   echo "Noting to do, No PR found, done!"

--- a/src/scripts/github-approve-prs.sh
+++ b/src/scripts/github-approve-prs.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-
 if [[ $(gh pr list) ]]; then
   echo "PR open listed. Notify to update"
   gh pr list | awk '{print$1}' | while read -r line; do
-    if [ $(gh pr view $line --json author --jq '.author.login') != "dft-deploy" ]; then
+    if [ "$(gh pr view $line --json author --jq '.author.login')" != "dft-deploy" ]; then
       gh pr review $line --request-changes --body "The staging env was chaged! You need to re-run this pipeline to create a new deploy to staging"
     fi
   done
@@ -11,7 +10,7 @@ fi
 if [[ $(gh pr list -H ${CIRCLE_BRANCH}) ]]; then
   echo "PR open listed. APPROVE"
   gh pr list -H ${CIRCLE_BRANCH} | awk '{print$1}' | while read -r line; do
-    if [ $(gh pr view $line --json author --jq '.author.login') != "dft-deploy" ]; then
+    if [ "$(gh pr view $line --json author --jq '.author.login')" != "dft-deploy" ]; then
       gh pr review $line --approve --body "Thi PR is ready to merge!"
     else
       gh pr close $line


### PR DESCRIPTION
- update github actions skip when the author is dft-deploy
- :zap:

# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->
When backstage is creating new apps, the first release action in pipeline break because the PR author is the same enity to approve

Issue Number: N/A

## What is the new behavior?
Orb job `github-approve` now check if the PR author is `dft-deployer` to skip approves and reviews changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
