### PR TITLE
fix: update github-update

### DIFF
--- a/src/scripts/github-approve-prs.sh
+++ b/src/scripts/github-approve-prs.sh
@@ -14,6 +14,7 @@ if [[ $(gh pr list -H ${CIRCLE_BRANCH}) ]]; then
       gh pr review $line --approve --body "Thi PR is ready to merge!"
     else
       gh pr close $line
+      git push -d origin ${CIRCLE_BRANCH}
     fi
   done
 else


### PR DESCRIPTION
Now when the branch is `release/first-release` and the PR author is `dft-deploy` delete branch and close PR automaticaly

# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->
When a new project is created via backstage, the branch `release/first-release` is not deleted at the end of process
Issue Number: PLT-407

## The new version

New release version candidate: v1.1.2

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?
Now when the job `github-approve` runs, the shell script validates if is `dft-deployer` the PR author and the branch name is `release/first-release` and then delete branch and close PR.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
