### PR TITLE
[SANV2-138576][V3.1.1] - fix deploy and promote jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # orb-standard-pipeline
 
+## `[3.1.1 2023-07-12]`
+
+### Changes
+
+Fix jobs:
+
+- `eks-deploy`
+- `eks-promote`
+
+Booth of then now has a flag `use_yq` with default value `true` that change the behavior of the action to change image tag in deployment file.
+
+The default image `cimg/base:stable` has the binary `yq` <https://mikefarah.gitbook.io/yq/> already installed that make ease to change values in yaml file like a pro.
+
+This feature will only work when de deployment file is a `kustomization.yaml` file that has the yaml structure like:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: example
+helmCharts:
+  - name: my-helm
+    version: 0.0.1
+    repo: https://my-repo.io
+    valuesInline:
+      image:
+        tag: "767ccdc" 
+```
+
+Then the command:
+
+```sh
+yq -i '.helmCharts[0].valuesInline.image.tag = "[new value]"'
+```
+
+
+### Added
+
+N\A
+
+### Removed
+
+N\A
+
+___
+
+
 ## `[3.1.0 2023-07-04]`
 
 ### Changes

--- a/src/examples/atual-workflow.yml
+++ b/src/examples/atual-workflow.yml
@@ -16,7 +16,7 @@ usage:
     branches:
       only: [master]
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/cloudfront-invalidate-cache.yml
+++ b/src/examples/cloudfront-invalidate-cache.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3.yml
+++ b/src/examples/deploy-to-s3.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/full-workflow.yml
+++ b/src/examples/full-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/grafana-notify.yml
+++ b/src/examples/grafana-notify.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/java-quarkus-workflow.yml
+++ b/src/examples/java-quarkus-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/lambda.yml
+++ b/src/examples/lambda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   test_filters: &test_filters
     branches:
       only: [/^feature.*/, /^hotfix.*/]

--- a/src/examples/partial-workflow.yml
+++ b/src/examples/partial-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.0
+    dft: dafiti-group/orb-standard-pipeline@3.1.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/jobs/eks-deploy.yml
+++ b/src/jobs/eks-deploy.yml
@@ -45,6 +45,12 @@ parameters:
       - backstage
       - kustomize
       Default value is CIRCLE_PROJECT_REPONAME that is the name of your repository in GitHub
+  use_yq:
+    type: boolean
+    default: true
+    description: |
+      Flag to use yq command to replace image tag instead of sed command
+      WARNING: use only if your project is using kustomization file!
 executor: small
 steps:
   - when:
@@ -68,6 +74,7 @@ steps:
         PARAMETER_ROLLBACK: <<parameters.rollback>>
         PARAMETER_VERSION: <<parameters.version>>
         PARAMETER_FILE_NAME: <<parameters.file_name>>
+        PARAMETER_USE_YQ: <<parameters.use_yq>>
       command: <<include(scripts/gitops-update.sh)>>
   - slack/notify:
       event: fail

--- a/src/jobs/eks-promote.yml
+++ b/src/jobs/eks-promote.yml
@@ -51,6 +51,12 @@ parameters:
     type: string
     default: gitops
     description: The repo name to clone deployments to change image tags
+  use_yq:
+    type: boolean
+    default: true
+    description: |
+      Flag to use yq command to replace image tag instead of sed command
+      WARNING: use only if your project is using kustomization file!
 executor: base
 steps:
   - config_git
@@ -66,6 +72,8 @@ steps:
         PARAMETER_DESTINY_PATH: <<parameters.destiny>>
         PARAMETER_COMPOSITE_DESTINY_PATH: "<<parameters.gitops>>/apps/<<parameters.country>>/<<parameters.app_name>>/<<parameters.destiny_env>>"
         PARAMETER_DESTINY_FILE: <<parameters.destiny_file>>
+        PARAMETER_USE_YQ: <<parameters.use_yq>>
+
       command: <<include(scripts/gitops-promote.sh)>>
   - slack/notify:
       event: fail

--- a/src/scripts/gitops-promote.sh
+++ b/src/scripts/gitops-promote.sh
@@ -23,13 +23,18 @@ if [ ! -f "${DESTINY_FILE}" ]; then
   exit 1
 fi
 
-NEW_TAG=$(grep "tag: " ${ORIGIN_FILE} | awk '{print$2}')
-OLD_TAG=$(grep "tag: " ${DESTINY_FILE} | awk '{print$2}')
-echo "NEW_TAG: ${NEW_TAG} OLD_TAG: ${OLD_TAG}"
-if [[ -z "$NEW_TAG" || -z "$OLD_TAG" ]]; then
-  echo "Error geting tags from files"
+if [ "${PARAMETER_USE_YQ}" -eq "1" ]; then
+  TAG=$(yq '.helmCharts[0].valuesInline.image.tag' ${ORIGIN_FILE})
+  yq -i '.helmCharts[0].valuesInline.image.tag = strenv(TAG)' ${DESTINY_FILE}
+else
+  NEW_TAG=$(grep "tag: " ${ORIGIN_FILE} | awk '{print$2}')
+  OLD_TAG=$(grep "tag: " ${DESTINY_FILE} | awk '{print$2}')
+  echo "NEW_TAG: ${NEW_TAG} OLD_TAG: ${OLD_TAG}"
+  if [[ -z "$NEW_TAG" || -z "$OLD_TAG" ]]; then
+    echo "Error geting tags from files"
+  fi
+  sed -i "s|${OLD_TAG}|${NEW_TAG}|" ${DESTINY_FILE}
 fi
-sed -i "s|${OLD_TAG}|${NEW_TAG}|" ${DESTINY_FILE}
 
 cd ${PARAMETER_START_FOLDER} || exit 1
 if [[ $(git diff) ]]; then

--- a/src/scripts/gitops-promote.sh
+++ b/src/scripts/gitops-promote.sh
@@ -25,11 +25,12 @@ fi
 
 if [ "${PARAMETER_USE_YQ}" -eq "1" ]; then
   TAG=$(yq '.helmCharts[0].valuesInline.image.tag' ${ORIGIN_FILE})
+  echo "Using YQ and new tag is:${TAG}"
   yq -i ".helmCharts[0].valuesInline.image.tag = \"${TAG}\"" ${DESTINY_FILE}
 else
   NEW_TAG=$(grep "tag: " ${ORIGIN_FILE} | awk '{print$2}')
   OLD_TAG=$(grep "tag: " ${DESTINY_FILE} | awk '{print$2}')
-  echo "NEW_TAG: ${NEW_TAG} OLD_TAG: ${OLD_TAG}"
+  echo "Using SED, NEW_TAG: ${NEW_TAG} OLD_TAG: ${OLD_TAG}"
   if [[ -z "$NEW_TAG" || -z "$OLD_TAG" ]]; then
     echo "Error geting tags from files"
   fi

--- a/src/scripts/gitops-promote.sh
+++ b/src/scripts/gitops-promote.sh
@@ -25,7 +25,7 @@ fi
 
 if [ "${PARAMETER_USE_YQ}" -eq "1" ]; then
   TAG=$(yq '.helmCharts[0].valuesInline.image.tag' ${ORIGIN_FILE})
-  yq -i '.helmCharts[0].valuesInline.image.tag = strenv(TAG)' ${DESTINY_FILE}
+  yq -i ".helmCharts[0].valuesInline.image.tag = \"${TAG}\"" ${DESTINY_FILE}
 else
   NEW_TAG=$(grep "tag: " ${ORIGIN_FILE} | awk '{print$2}')
   OLD_TAG=$(grep "tag: " ${DESTINY_FILE} | awk '{print$2}')

--- a/src/scripts/gitops-update.sh
+++ b/src/scripts/gitops-update.sh
@@ -6,16 +6,24 @@ if [[ ! -d "${LOCAL_DEPLOYMENT_PATH}" ]]; then
   exit 1
 fi
 cd ${LOCAL_DEPLOYMENT_PATH} || exit 1
-IMAGE="tag: \"${CIRCLE_SHA1:0:7}\""
+IMAGE=${CIRCLE_SHA1:0:7}
 if [ "${PARAMETER_ROLLBACK}" -eq "1" ]; then
-  IMAGE="tag: \"${PARAMETER_VERSION}\""
+  IMAGE=${PARAMETER_VERSION}
 fi
 CONFIG_FILE=$(eval echo "${PARAMETER_FILE_NAME}.yaml")
 if [ ! -f "${CONFIG_FILE}" ]; then
   echo "file ${LOCAL_DEPLOYMENT_PATH}/${CONFIG_FILE} not found!"
   exit 1
 fi
-sed -Ei "s|tag: \".*\"|${IMAGE}|" ${CONFIG_FILE}
+
+if [ "${PARAMETER_USE_YQ}" -eq "1" ]; then
+  yq -i '.helmCharts[0].valuesInline.image.tag = strenv(IMAGE)' $CONFIG_FILE
+else
+  IMAGE="tag: \"${IMAGE}\""
+  sed -Ei "s|tag: \".*\"|${IMAGE}|" ${CONFIG_FILE}
+fi
+
+
 if [[ $(git diff) ]]; then
   git diff
   git add .

--- a/src/scripts/gitops-update.sh
+++ b/src/scripts/gitops-update.sh
@@ -17,7 +17,7 @@ if [ ! -f "${CONFIG_FILE}" ]; then
 fi
 
 if [ "${PARAMETER_USE_YQ}" -eq "1" ]; then
-  yq -i '.helmCharts[0].valuesInline.image.tag = strenv(IMAGE)' $CONFIG_FILE
+  yq -i ".helmCharts[0].valuesInline.image.tag = \"${IMAGE}\"" $CONFIG_FILE
 else
   IMAGE="tag: \"${IMAGE}\""
   sed -Ei "s|tag: \".*\"|${IMAGE}|" ${CONFIG_FILE}

--- a/src/scripts/gitops-update.sh
+++ b/src/scripts/gitops-update.sh
@@ -17,9 +17,11 @@ if [ ! -f "${CONFIG_FILE}" ]; then
 fi
 
 if [ "${PARAMETER_USE_YQ}" -eq "1" ]; then
+  echo "Using YQ and new tag is: ${IMAGE}"
   yq -i ".helmCharts[0].valuesInline.image.tag = \"${IMAGE}\"" $CONFIG_FILE
 else
   IMAGE="tag: \"${IMAGE}\""
+  echo "Using SED and new tag is: ${IMAGE}"
   sed -Ei "s|tag: \".*\"|${IMAGE}|" ${CONFIG_FILE}
 fi
 


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->
The jobs `deploy` and `promote` use sed command to change image.tag deployment and some projects has more than one image in template and this approuch broke the pipeline

Issue Number: [SANV2-138576](https://dafiti.jira.com/browse/SANV2-138576)

## The new version

New release version candidate: v3.1.1

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?

Now those jobs, `deploy` and `promote` uses `yq` command to precisely change only `.helmCharts[0].valuesInline.image.tag` data

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The capability of use `yq` as change tool is set as default but the old approch still available to cover legacy scenarios


[SANV2-138576]: https://dafiti.jira.com/browse/SANV2-138576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ