### PR TITLE
[PLT-824][v3.1.2] fix validate hash in rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # orb-standard-pipeline
 
+## `[3.1.2 2023-07-24]`
+
+### Changes
+
+- dft/eks-deploy fix the action for rollback, stop validating if the hash existis in github and validate if the aws ecr has the desired image hash
+
+### Added
+
+N\A
+
+### Removed
+
+N\A
+
+___
+
 ## `[3.1.1 2023-07-12]`
 
 ### Changes
@@ -197,12 +213,12 @@ ___
       context: [DEFAULT]
   ```
 
-  The `eks-promote` job will automatically get the `image.tag` from `gitops/apps/${COUNTRY}/${CIRCLECI_PROJECT_REPONAME}/qa/kustomization.yaml` to replace in `gitops/apps/${COUNTRY}/${CIRCLECI_PROJECT_REPONAME}/live/kustomization.yaml`. There are more variables to handle this job like:
+  The `eks-promote` job will automatically get the `image.tag` from `gitops/apps/${COUNTRY}/${CIRCLE_PROJECT_REPONAME}/qa/kustomization.yaml` to replace in `gitops/apps/${COUNTRY}/${CIRCLE_PROJECT_REPONAME}/live/kustomization.yaml`. There are more variables to handle this job like:
   | parameter     | type     | description                                                |
   | :------------ | :------- | :--------------------------------------------------------- |
-  | `app_name`    | `string` | Default is env `$CIRCLECI_PROJECT_REPONAME`                |
+  | `app_name`    | `string` | Default is env `$CIRCLE_PROJECT_REPONAME`                |
   | `origin_env`  | `string` | Default is `qa`, the folder name where to get `image.tag`  |
   | `destiny_env` | `string` | Default `live`, the folder name where to place `image.tag` |
   | `origin`      | `string` | Override all path creation to get the `image.tag` from     |
   | `destiny`     | `string` | Override all path creation to place the `image.tag`        |
-- Changes `instana-notify` job, the parameter `service_name` to default `${CIRCLECI_PROJECT_REPONAME}.${COUNTRY}.${ENV_SHORT}`
+- Changes `instana-notify` job, the parameter `service_name` to default `${CIRCLE_PROJECT_REPONAME}.${COUNTRY}.${ENV_SHORT}`

--- a/src/examples/atual-workflow.yml
+++ b/src/examples/atual-workflow.yml
@@ -16,7 +16,7 @@ usage:
     branches:
       only: [master]
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/cloudfront-invalidate-cache.yml
+++ b/src/examples/cloudfront-invalidate-cache.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3.yml
+++ b/src/examples/deploy-to-s3.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/full-workflow.yml
+++ b/src/examples/full-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/grafana-notify.yml
+++ b/src/examples/grafana-notify.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/java-quarkus-workflow.yml
+++ b/src/examples/java-quarkus-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/lambda.yml
+++ b/src/examples/lambda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   test_filters: &test_filters
     branches:
       only: [/^feature.*/, /^hotfix.*/]

--- a/src/examples/partial-workflow.yml
+++ b/src/examples/partial-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.1
+    dft: dafiti-group/orb-standard-pipeline@3.1.2
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/jobs/eks-deploy.yml
+++ b/src/jobs/eks-deploy.yml
@@ -58,6 +58,7 @@ steps:
         equal: [true, <<parameters.rollback>>]
       steps:
         - checkout
+        - aws-ecr/ecr-login
         - run:
             name: Validating version hash to rollback
             environment:

--- a/src/scripts/validate-hash.sh
+++ b/src/scripts/validate-hash.sh
@@ -4,8 +4,15 @@ if [[ -z "${PARAMETER_VERSION}" ]]; then
   echo "Missing parameter PARAMETER_VERSION"
   exit 1
 fi
-VALIDATE_VERSION=$(git rev-parse --verify ${PARAMETER_VERSION})
-if [[ -z "${VALIDATE_VERSION}" ]]; then
-  echo "Invalid hash version"
+
+echo "VALIDATING IF THE TAG:${PARAMETER_VERSION} EXISTIS IN AWS ECR"
+
+LOCAL_IMAGE_TAGS=$(aws ecr list-images --repository-name "${CIRCLE_PROJECT_REPONAME}" | jq -r '.imageIds[].imageTag')
+if echo $LOCAL_IMAGE_TAGS | grep -oq "${PARAMETER_VERSION}"; then
+  echo "Registry found, OK-2-GO"
+  exit 0
+else
+  echo "Registry not found. Available tags is:"
+  echo ${LOCAL_IMAGE_TAGS}
   exit 1
 fi


### PR DESCRIPTION
- fix: validate hash to rollback in aws ecr
- chore: update docs and changelog

# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->
The job `eks-deploy` when running at rollback context generates an error trying to validate the hash to rollback to. 

Issue Number: [PLT-824](https://dafiti.jira.com/browse/PLT-824)

## The new version

New release version candidate: v3.1.2?

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?

Now the job `eks-deploy` in the rollback context validate if the hash exists in `AWS ECR` instead of github commit logs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


[PLT-824]: https://dafiti.jira.com/browse/PLT-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ