### PR TITLE
[v3.2.0] - including new docker ARN builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # orb-standard-pipeline
 
+
+
+## `[3.2.0 2023-11-08]`
+
+### Changes
+
+- New executor `arn` to be used in `ecr-build-and-push`
+- Update `job ecr-build-and-push` including a new parameter `docker_version` to setup custom docker versions
+- Update command `config_docker`  including a new parameter `version` to setup docker context
+
+### Added
+
+N\A
+
+### Removed
+
+N\A
+
+___
+
+
 ## `[3.1.2 2023-07-24]`
 
 ### Changes

--- a/src/commands/config_docker.yml
+++ b/src/commands/config_docker.yml
@@ -1,5 +1,11 @@
 description: Used to setup all dockers with same configurations
+parameters:
+  version:
+    type: string
+    description: The docker version to setup builds, Find more at <https://circleci.com/docs/building-docker-images/#docker-version>
+    default: "20.10.14"
+
 steps:
   - setup_remote_docker:
       docker_layer_caching: false
-      version: 20.10.14
+      version: <<parameters.version>>

--- a/src/examples/arn-example.yml
+++ b/src/examples/arn-example.yml
@@ -1,0 +1,12 @@
+description: This example show only how to setup the job ecr-build-and-push to use ARN architecture
+usage:
+  version: 2.1
+  orbs:
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
+  workflows:
+    deployment-flow:
+      jobs:
+        - dft/ecr-build-and-push:
+            context: [DEFAULT]
+            runner: dft/arn
+            docker_version: default

--- a/src/examples/atual-workflow.yml
+++ b/src/examples/atual-workflow.yml
@@ -16,7 +16,7 @@ usage:
     branches:
       only: [master]
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/cloudfront-invalidate-cache.yml
+++ b/src/examples/cloudfront-invalidate-cache.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3.yml
+++ b/src/examples/deploy-to-s3.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/full-workflow.yml
+++ b/src/examples/full-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/grafana-notify.yml
+++ b/src/examples/grafana-notify.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/java-quarkus-workflow.yml
+++ b/src/examples/java-quarkus-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/lambda.yml
+++ b/src/examples/lambda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   test_filters: &test_filters
     branches:
       only: [/^feature.*/, /^hotfix.*/]

--- a/src/examples/partial-workflow.yml
+++ b/src/examples/partial-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.1.2
+    dft: dafiti-group/orb-standard-pipeline@3.2.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/executors/arn.yml
+++ b/src/executors/arn.yml
@@ -1,0 +1,6 @@
+description: |
+  ARN base OS for docker builds
+  To use this executor, please change docker version to 'default'
+docker:
+  - image: cimg/base:2023.06
+resource_class: arm.medium

--- a/src/jobs/ecr-build-and-push.yml
+++ b/src/jobs/ecr-build-and-push.yml
@@ -67,10 +67,15 @@ parameters:
     type: string
     default: Dockerfile
     description: The path/file name of customized docker file
+  docker_version:
+    type: string
+    description: The docker version to setup builds, Find more at <https://circleci.com/docs/building-docker-images/#docker-version>
+    default: "20.10.14"
 executor: <<parameters.runner>>
 steps:
   - checkout
-  - config_docker
+  - config_docker:
+      version: <<parameters.docker_version>>
   - aws-ecr/ecr-login
   - rev_txt:
       rev_txt_path: <<parameters.rev_txt_path>>


### PR DESCRIPTION
# PR Type
`MINOR`

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->

Issue Number: N/A

## The new version

New release version candidate: `v3.2.0`

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?

Now the orb can be used to build `ARN` docker images.
To use it, on the job `ecr-build-and-push` include parameters:

```yaml
- dft/ecr-build-and-push:
    context: [DEFAULT]
    runner: dft/arn
    docker_version: default
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
