### PR TITLE
[NAS-141] - include aditional steps to build on pipeline

### DIFF
--- a/src/examples/arn-example.yml
+++ b/src/examples/arn-example.yml
@@ -2,7 +2,7 @@ description: This example show only how to setup the job ecr-build-and-push to u
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/atual-workflow.yml
+++ b/src/examples/atual-workflow.yml
@@ -16,7 +16,7 @@ usage:
     branches:
       only: [master]
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/cloudfront-invalidate-cache.yml
+++ b/src/examples/cloudfront-invalidate-cache.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-latam.yml
+++ b/src/examples/deploy-latam.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/deploy-to-s3-static.yml
+++ b/src/examples/deploy-to-s3-static.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3.yml
+++ b/src/examples/deploy-to-s3.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/full-workflow.yml
+++ b/src/examples/full-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/grafana-notify.yml
+++ b/src/examples/grafana-notify.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/java-quarkus-workflow.yml
+++ b/src/examples/java-quarkus-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/lambda.yml
+++ b/src/examples/lambda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   test_filters: &test_filters
     branches:
       only: [/^feature.*/, /^hotfix.*/]

--- a/src/examples/partial-workflow.yml
+++ b/src/examples/partial-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.5.0
+    dft: dafiti-group/orb-standard-pipeline@3.6.0
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/jobs/unit-test.yml
+++ b/src/jobs/unit-test.yml
@@ -7,7 +7,24 @@ parameters:
   services:
     type: string
     default: ""
-    description: Use to include additional docker-compose services to build
+    description: |
+      Use to include additional docker-compose services to build ex:
+      ```yaml
+      # docker-compose.yaml
+      services:
+        ci:
+          # ...
+        ci_database:
+          image: my-project-customized-database
+          build:
+            # ...
+      ```
+      Then use on your pipline
+      ```yaml
+        dft/unit-test:
+          context: [DEFAULT]
+          services: ci_database # only extra services
+      ```
   build_args:
     type: string
     default: ""

--- a/src/jobs/unit-test.yml
+++ b/src/jobs/unit-test.yml
@@ -83,7 +83,7 @@ steps:
         - persist_to_workspace:
             root: .
             paths:
-            - <<parameters.coverage_file>>
+              - <<parameters.coverage_file>>
   - slack/notify:
       event: fail
       custom: <<include(templates/fail.json)>>

--- a/src/jobs/unit-test.yml
+++ b/src/jobs/unit-test.yml
@@ -4,10 +4,10 @@ description: |
   Needs:
     context: [DEFAULT]
 parameters:
-  build_extra_services:
+  services:
     type: string
     default: ""
-    description: Use to include more than ci service to build
+    description: Use to include additional docker-compose services to build
   build_args:
     type: string
     default: ""
@@ -66,7 +66,10 @@ steps:
       command: docker network create docker-dafiti_default || true
   - run:
       name: Build ci image test
-      command: docker-compose build <<parameters.build_args>> ci <<parameters.build_extra_services>>
+      environments:
+        SERVICES: <<parameters.services>>
+        BUILD_ARGS: <<parameters.build_args>>
+      command: docker-compose build ${BUILD_ARGS} ci ${SERVICES}
   - run:
       name: Run unit tests
       command: docker-compose run --name dafiti_ci ci

--- a/src/jobs/unit-test.yml
+++ b/src/jobs/unit-test.yml
@@ -4,6 +4,10 @@ description: |
   Needs:
     context: [DEFAULT]
 parameters:
+  build_extra_services:
+    type: string
+    default: ""
+    description: Use to include more than ci service to build
   build_args:
     type: string
     default: ""
@@ -62,7 +66,7 @@ steps:
       command: docker network create docker-dafiti_default || true
   - run:
       name: Build ci image test
-      command: docker-compose build <<parameters.build_args>> ci
+      command: docker-compose build <<parameters.build_args>> ci <<parameters.build_extra_services>>
   - run:
       name: Run unit tests
       command: docker-compose run --name dafiti_ci ci


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->
The job `unit-test` builds only the service name `ci`

Issue Number: N/A

## The new version

New release version candidate: v3.6.0

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?

Now the job `unit-test` has the parameter `build_extra_services` to allow include more services to be build at once

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This feature is necessary because `bob` uses `flyway` on pipline that needs to be build before start services
