### PR TITLE
hotfix including sam cli version outside override

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -17,7 +17,7 @@ orbs:
   aws-cli: circleci/aws-cli@2.0.3 # needs context: [DEFAULT, (LIVE | QA | LIVE_AWS_DAFITI)]
   aws-ecr: circleci/aws-ecr@7.3.0 # needs context: DEFAULT
   aws-s3: circleci/aws-s3@3.1 # needs context: [DEFAULT, (LIVE | QA | LIVE_AWS_DAFITI)]
-  sam: circleci/aws-sam-serverless@3.0 # needs context: [DEFAULT, (LIVE | QA | LIVE_AWS_DAFITI)]
+  sam: circleci/aws-sam-serverless@3.3.0 # needs context: [DEFAULT, (LIVE | QA | LIVE_AWS_DAFITI)]
   cxflow: checkmarx-ts/cxflow@1.0.6 # needs context: DEFAULT
   github-cli: circleci/github-cli@2.1.0 # needs one of  context: DEFAULT
   pipeline-feedback: instana/pipeline-feedback@2.0.3 # needs context: [DEFAULT, (LIVE | QA | LIVE_AWS_DAFITI)]

--- a/src/examples/arn-example.yml
+++ b/src/examples/arn-example.yml
@@ -2,7 +2,7 @@ description: This example show only how to setup the job ecr-build-and-push to u
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/atual-workflow.yml
+++ b/src/examples/atual-workflow.yml
@@ -16,7 +16,7 @@ usage:
     branches:
       only: [master]
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/cloudfront-invalidate-cache.yml
+++ b/src/examples/cloudfront-invalidate-cache.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3-static.yml
+++ b/src/examples/deploy-to-s3-static.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3.yml
+++ b/src/examples/deploy-to-s3.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/full-workflow.yml
+++ b/src/examples/full-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/grafana-notify.yml
+++ b/src/examples/grafana-notify.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/java-quarkus-workflow.yml
+++ b/src/examples/java-quarkus-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/lambda.yml
+++ b/src/examples/lambda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   test_filters: &test_filters
     branches:
       only: [/^feature.*/, /^hotfix.*/]

--- a/src/examples/multi-country.yml
+++ b/src/examples/multi-country.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/partial-workflow.yml
+++ b/src/examples/partial-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.10.0
+    dft: dafiti-group/orb-standard-pipeline@3.10.1
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/jobs/sam-deploy.yml
+++ b/src/jobs/sam-deploy.yml
@@ -23,11 +23,16 @@ parameters:
     type: boolean
     default: true
     description: flag to use container as builder
+  sam_cli_version:
+    type: string
+    default: latest
+    description: SAM CLI version to be installed.
 executor: machine
 steps:
   - checkout
   - config_git
-  - sam/install
+  - sam/install:
+      version: <<parameters.sam_cli_version>>
   - run:
       name: Deploy lambda funcion
       environment:


### PR DESCRIPTION
original issue: https://github.com/aws/aws-sam-cli/issues/8143

# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->

AWS SAM CLI latest start fail to use `sam deploy` command as liked below:

Issue Number: https://github.com/aws/aws-sam-cli/issues/8143

## The new version

New release version candidate: v3.10.1?

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?

Now the `sam-deploy` job has the parameter override `sam_cli_version` to change outside orb vertion to by-pass this issue

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
