### PR TITLE
[ :robot: ]  New config to upload artifacts to azion edge storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # orb-standard-pipeline
 
+## `[3.11.4 2026-03-17]`
+
+### Changes
+
+- **deploy-to-s3**: Replaced `circleci/aws-s3` orb `sync` command with a direct `aws-cli/setup` + `aws s3 sync` invocation.
+  - **Fix**: The upstream `aws-s3/sync` command wrapped the `arguments` parameter in quotes, causing multi-token arguments (e.g., `--endpoint-url <url>`) to be passed as a single string to the AWS CLI, resulting in `ParamValidation: Unknown options` errors.
+  - **Improvement**: Custom credentials (`aws-access-key-id`, `aws-secret-access-key`) are now properly forwarded through `aws-cli/setup`, enabling S3-compatible storage providers (e.g., Azion Edge Storage) to work correctly.
+
+  This refactor enables uploading artifacts to Azion Edge Storage (or any S3-compatible provider) by allowing custom credentials and endpoint configuration through the `arguments` parameter. Usage example:
+
+  ```yaml
+  - dft/deploy-to-s3:
+      context: [DEFAULT, QA]
+      aws-access-key-id: AZION_S3_ACCESS_KEY
+      aws-secret-access-key: AZION_S3_SECRET_KEY
+      arguments: --profile default --endpoint-url $AZION_S3_ENDPOINT
+      bucket: s3://bob-br-qa-data-storage/temporary_files/
+      use_docker_build: false
+      folder: app1
+  ```
+
+### Added
+
+N\A
+
+### Removed
+
+N\A
+
+
+
 ## `[3.11.3 2025-12-07]`
 
 ### Changes

--- a/src/examples/arn-example.yml
+++ b/src/examples/arn-example.yml
@@ -2,7 +2,7 @@ description: This example show only how to setup the job ecr-build-and-push to u
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/atual-workflow.yml
+++ b/src/examples/atual-workflow.yml
@@ -16,7 +16,7 @@ usage:
     branches:
       only: [master]
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/cloudfront-invalidate-cache.yml
+++ b/src/examples/cloudfront-invalidate-cache.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3-static.yml
+++ b/src/examples/deploy-to-s3-static.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/deploy-to-s3.yml
+++ b/src/examples/deploy-to-s3.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/full-workflow.yml
+++ b/src/examples/full-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/grafana-notify.yml
+++ b/src/examples/grafana-notify.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   workflows:
     deployment-flow:
       jobs:

--- a/src/examples/java-quarkus-workflow.yml
+++ b/src/examples/java-quarkus-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/lambda.yml
+++ b/src/examples/lambda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   test_filters: &test_filters
     branches:
       only: [/^feature.*/, /^hotfix.*/]

--- a/src/examples/mult-arch-workflow.yml
+++ b/src/examples/mult-arch-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/multi-country.yml
+++ b/src/examples/multi-country.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/examples/partial-workflow.yml
+++ b/src/examples/partial-workflow.yml
@@ -17,7 +17,7 @@ usage:
       description: The commit hash to revert deployment
   # including dft org
   orbs:
-    dft: dafiti-group/orb-standard-pipeline@3.11.3
+    dft: dafiti-group/orb-standard-pipeline@3.11.4
   # reserved filters anchors
   test_filters: &test_filters
     branches:

--- a/src/jobs/deploy-to-s3.yml
+++ b/src/jobs/deploy-to-s3.yml
@@ -17,6 +17,7 @@ parameters:
   arguments:
     type: string
     description: Arguments to be used in S3 aws-s3/sync
+    default: ""
   runner:
     type: executor
     default: base
@@ -48,6 +49,14 @@ parameters:
       ```
       To use a customized runner, see this documentation https://circleci.com/docs/reusing-config#executor
       Use CircleCI images -> https://circleci.com/developer/images
+  aws-access-key-id:
+    default: AWS_ACCESS_KEY_ID
+    description: aws access key id override
+    type: env_var_name
+  aws-secret-access-key:
+    default: AWS_SECRET_ACCESS_KEY
+    description: aws secret access key override
+    type: env_var_name
 executor: <<parameters.runner>>
 steps:
   - checkout
@@ -61,10 +70,13 @@ steps:
             command: DOCKER_BUILDKIT=1 docker build -t deploy-to-s3 -o <<parameters.folder>> .
         - store_artifacts:
             path: out/
-  - aws-s3/sync:
-      from: <<parameters.folder>>
-      to: <<parameters.bucket>>
-      arguments: <<parameters.arguments>>
+  - aws-cli/setup:
+      aws-access-key-id: <<parameters.aws-access-key-id>>
+      aws-secret-access-key: <<parameters.aws-secret-access-key>>
+  - run:
+      name: S3 Sync
+      command: |
+        aws s3 sync <<parameters.folder>> <<parameters.bucket>> <<parameters.arguments>>
   - slack/notify:
       event: fail
       custom: <<include(templates/fail.json)>>

--- a/src/jobs/deploy-to-s3.yml
+++ b/src/jobs/deploy-to-s3.yml
@@ -69,7 +69,7 @@ steps:
             name: build artifact
             command: DOCKER_BUILDKIT=1 docker build -t deploy-to-s3 -o <<parameters.folder>> .
         - store_artifacts:
-            path: out/
+            path: <<parameters.folder>>
   - aws-cli/setup:
       aws-access-key-id: <<parameters.aws-access-key-id>>
       aws-secret-access-key: <<parameters.aws-secret-access-key>>

--- a/src/jobs/deploy-to-s3.yml
+++ b/src/jobs/deploy-to-s3.yml
@@ -75,8 +75,11 @@ steps:
       aws-secret-access-key: <<parameters.aws-secret-access-key>>
   - run:
       name: S3 Sync
-      command: |
-        aws s3 sync <<parameters.folder>> <<parameters.bucket>> <<parameters.arguments>>
+      environment:
+        PARAMETER_FOLDER: <<parameters.folder>>
+        PARAMETER_BUCKET: <<parameters.bucket>>
+        PARAMETER_ARGUMENTS: <<parameters.arguments>>
+      command: <<include(scripts/deploy-to-s3.sh)>>
   - slack/notify:
       event: fail
       custom: <<include(templates/fail.json)>>

--- a/src/scripts/deploy-to-s3.sh
+++ b/src/scripts/deploy-to-s3.sh
@@ -2,12 +2,12 @@
 
 if [[ -z "${PARAMETER_FOLDER}" ]]; then
   echo "the parameter ${PARAMETER_FOLDER} could not be empty"
-  exti 1
+  exit 1
 fi
 if [[ -z "${PARAMETER_BUCKET}" ]]; then
   echo "the parameter ${PARAMETER_BUCKET} could not be empty"
-  exti 1
+  exit 1
 fi
 
 RESOLVED_ARGUMENTS=$(eval echo "${PARAMETER_ARGUMENTS}")
-aws s3 sync ${PARAMETER_FOLDER} ${PARAMETER_BUCKET} ${RESOLVED_ARGUMENTS}
+aws s3 sync "${PARAMETER_FOLDER}" "${PARAMETER_BUCKET}" ${RESOLVED_ARGUMENTS}

--- a/src/scripts/deploy-to-s3.sh
+++ b/src/scripts/deploy-to-s3.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ -z "${PARAMETER_FOLDER}" ]]; then
+  echo "the parameter ${PARAMETER_FOLDER} could not be empty"
+  exti 1
+fi
+if [[ -z "${PARAMETER_BUCKET}" ]]; then
+  echo "the parameter ${PARAMETER_BUCKET} could not be empty"
+  exti 1
+fi
+
+RESOLVED_ARGUMENTS=$(eval echo "${PARAMETER_ARGUMENTS}")
+aws s3 sync ${PARAMETER_FOLDER} ${PARAMETER_BUCKET} ${RESOLVED_ARGUMENTS}


### PR DESCRIPTION
# PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [x] Refactoring (no functional changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or linking to a relevant issue. -->

- Job `deploy-to-s3` does not suport auth customizations to upload artifacts to `AZION EDGE STORAGE`

Issue Number: N/A

## The new version

New release version candidate: v3.11.4

>Reviewers, please check if the release candidate is present in the changes of this PR in the examples section!

## What is the new behavior?

- Job `deploy-to-s3` now uses direct `aws cli` command to upload files using `aws s3 sync` command. The job now can upload artifacts to AZION EDGE STORAGE as example

```yaml
  - dft/deploy-to-s3:
      context: [DEFAULT, QA]
      aws-access-key-id: AZION_S3_ACCESS_KEY
      aws-secret-access-key: AZION_S3_SECRET_KEY
      arguments: --profile default --endpoint-url $AZION_S3_ENDPOINT
      bucket: s3://bob-br-qa-data-storage/temporary_files/
      use_docker_build: false
      folder: app1
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
